### PR TITLE
Modify Openresty Install and add new uninstall function

### DIFF
--- a/checkos/checkos.go
+++ b/checkos/checkos.go
@@ -1,0 +1,102 @@
+package checkos
+
+import (
+	"fmt"
+        "net/http"
+        "runtime"
+	"os"
+	"bufio"
+	"strings"
+)
+
+//func Ostype() {
+//        http.HandleFunc("/ostype", DetectOS)
+//}
+
+func DetectOS (w http.ResponseWriter, r *http.Request) string{
+        // Detect OS
+        o := runtime.GOOS
+        switch o {
+        case "windows":
+                //fmt.Printf("Windows")
+                w.Header().Set("Content-Type", "application/json")
+                //json.NewEncoder(w).Encode(os)
+                fmt.Fprintf(w, `{"message": "Great, you are running %v."}`, o)
+        case "darwin":
+                // fmt.Println("MAC operating system")
+                w.Header().Set("Content-Type", "application/json")
+                // json.NewEncoder(w).Encode(os)
+                fmt.Fprintf(w, `{"message": "Great, you are running %v."}`, o)
+        case "linux":
+                // fmt.Println("Linux")
+                w.Header().Set("Content-Type", "application/json")
+                //json.NewEncoder(w).Encode(os)
+                //fmt.Fprintf(w, `{"message": "Great, you are running %v."}`, o)
+		return o
+                // Detect Linux distribution
+                //detectLinuxDist(w, r, o)
+                // Install Openresty
+                // InstallOpenresty()
+
+        default:
+                // fmt.Printf("%s.\n", os)
+                //fmt.Printf("The operating system is not supported!")
+                w.Header().Set("Content-Type", "application/json")
+                fmt.Fprintf(w, `{"message": "The operating system is not supported!"}`)
+        }
+
+        // Install Openresty
+        // Return a JSON for the installation status
+        // fmt.Println(os(w, r))
+	return o 
+}
+
+func DetectLinuxDist(w http.ResponseWriter, r *http.Request) string  {
+        file, err := os.Open("/etc/os-release")
+        if err != nil {
+                panic(err)
+        }
+        defer file.Close()
+
+        scanner := bufio.NewScanner(file)
+        for scanner.Scan() {
+                line := scanner.Text()
+                if strings.HasPrefix(line, "NAME=") {
+                        distro := strings.TrimPrefix(line, "NAME=")
+                        distro = strings.Trim(distro, "\"")
+                        // fmt.Println("Distribution:", distro)
+                        // fmt.Println(distro)
+                        w.Header().Set("Content-Type", "application/json")
+                        //fmt.Fprintf(w, `{"message": "You are running %v Linux!"}`, distro)
+                        //detectLinuxFlavour(w, r, distro)
+                        //break
+			return distro
+                }
+        }
+
+	return "" 
+}
+
+func DetectLinuxFlavour (w http.ResponseWriter, r *http.Request, distro string) {
+        switch distro {
+        case "Ubuntu":
+                //fmt.Fprintf(w, `{"Install Openresty on %v Linux......\n"}`, distro)
+                //ubuntuopenrestyInstall(w, r)
+                //installStatus()
+                //http.HandleFunc("/v1/openresty_install_status", installStatus())
+                //out, err := exec.Command("bash", "-c", "./install_openresty.sh").Output()
+                //if err != nil {
+                //   fmt.Printf("%s", err)
+                //}
+                fmt.Fprintf(w, `{"%v"}`, distro)
+        case "CentOS":
+                //fmt.Printf("Install Openresty on %v.", distro)
+                fmt.Fprintf(w, `{"%v"}`, distro)
+        case "Amazon Linux":
+                //fmt.Printf("Install Openresty on %v.", distro)
+                fmt.Fprintf(w, `{"%v"}`, distro)
+        default:
+                fmt.Fprintf(w, `{"The operating system is not supported!"}`)
+	}
+	return
+ }

--- a/checkos/go.mod
+++ b/checkos/go.mod
@@ -1,0 +1,3 @@
+module checkos
+
+go 1.19

--- a/go.work
+++ b/go.work
@@ -2,6 +2,7 @@ go 1.19
 
 use (
 	.
+	./checkos
 	./homepage
 	./openresty
 	./webserver

--- a/openresty/install_test.sh
+++ b/openresty/install_test.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-echo "Testing the bash script for Openresty............"
-

--- a/openresty/openresty.go
+++ b/openresty/openresty.go
@@ -1,18 +1,12 @@
 package openresty
 
 import (
-	"bufio"
-	"fmt"
 	"net/http"
-	"os"
-	"runtime"
-	"strings"
-	"os/exec"
-	//"encoding/json"
 )
 
 func OpenrestyConf() {
 	http.HandleFunc("/v1/openresty_install", openrestyInstall)
+	http.HandleFunc("/v1/openresty_uninstall", openrestyUninstall)
 	http.HandleFunc("/v1/openresty_ping", openrestyStatus)
 	http.HandleFunc("/v1/openresty_version", openrestyVersion)
 	http.HandleFunc("/v1/openresty_start", openrestyStart)
@@ -25,141 +19,3 @@ func OpenrestyConf() {
         http.HandleFunc("/v1/openresty_config_test", openrestyconfTest)
 }
 
-
-func openrestyInstall(w http.ResponseWriter, r *http.Request) {
-
-	// Detect OS
-	o := runtime.GOOS
-	switch o {
-	case "windows":
-		//fmt.Printf("Windows")
-		w.Header().Set("Content-Type", "application/json")
-		//json.NewEncoder(w).Encode(os)
-		fmt.Fprintf(w, `{"message": "Great, you are running %v."}`, o)
-	case "darwin":
-		// fmt.Println("MAC operating system")
-		w.Header().Set("Content-Type", "application/json")
-		// json.NewEncoder(w).Encode(os)
-		fmt.Fprintf(w, `{"message": "Great, you are running %v."}`, o)
-	case "linux":
-		// fmt.Println("Linux")
-		w.Header().Set("Content-Type", "application/json")
-		//json.NewEncoder(w).Encode(os)
-		//fmt.Fprintf(w, `{"message": "Great, you are running %v."}`, o)
-		// Detect Linux distribution
-		DetectLinuxDist(w, r, o)
-		// Install Openresty
-		// InstallOpenresty()
-
-	default:
-		// fmt.Printf("%s.\n", os)
-		//fmt.Printf("The operating system is not supported!")
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"message": "The operating system is not supported!"}`)
-	}
-
-	// Install Openresty
-
-	// Return a JSON for the installation status
-	// fmt.Println(os(w, r))
-}
-
-func DetectLinuxDist(w http.ResponseWriter, r *http.Request, o string) {
-	file, err := os.Open("/etc/os-release")
-	if err != nil {
-		panic(err)
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, "NAME=") {
-			distro := strings.TrimPrefix(line, "NAME=")
-			distro = strings.Trim(distro, "\"")
-			// fmt.Println("Distribution:", distro)
-			// fmt.Println(distro)
-			w.Header().Set("Content-Type", "application/json")
-			//fmt.Fprintf(w, `{"message": "You are running %v Linux!"}`, distro)
-			InstallOpenresty(w, r, distro)
-			break
-		}
-	}
-}
-
-func InstallOpenresty (w http.ResponseWriter, r *http.Request, distro string) {
- 	switch distro {
- 	case "Ubuntu":
- 		//fmt.Fprintf(w, `{"Install Openresty on %v Linux......\n"}`, distro)
- 		deployOpenresty(w, r)
- 		//installStatus()
- 		//http.HandleFunc("/v1/openresty_install_status", installStatus())
- 		//out, err := exec.Command("bash", "-c", "./install_openresty.sh").Output()
- 		//if err != nil {
- 		//   fmt.Printf("%s", err)
- 		//}
- 		//fmt.Printf("%s", out)
- 	case "CentOS":
- 		fmt.Printf("Install Openresty on %v.", distro)
- 	case "Amazon Linux":
- 		fmt.Printf("Install Openresty on %v.", distro)
- 	default:
- 		fmt.Println("The operating system is not supported!.")
- 	}
- }
-
-func deployOpenresty (w http.ResponseWriter, r *http.Request) {
-
- 	//output, err := exec.Command("openresty", "-v").CombinedOutput()
- 	_, err := exec.Command("openresty", "-v").CombinedOutput()
- 	if err != nil {
-		//w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `{"status": 200, "response": "OpenResty installation started. Call /v1/openresty_ping to find out the status of the installation"}`)
- 		//fmt.Println("OpenResty is not installed")
- 		//return
- 		//out, err := exec.Command("bash", "-c", "./openresty/install_openresty.sh").Output()
- 		_, err := exec.Command("bash", "-c", "./openresty/install_openresty.sh").Output()
- 		if err != nil {
-		        w.Header().Set("Content-Type", "application/json")
- 			fmt.Printf("%s", err)
-			fmt.Fprintf(w, `{"%s"}`, err)
- 		
-		}
-
-		//installStatus(w, r)
-
- 		//fmt.Printf("%s", out)
- 	} else {
-		//w.Header().Set("Content-Type", "application/json")
-		//w.WriteHeader(http.StatusOK)
- 	        //fmt.Printf("Openresty is already installed.\n")
-		fmt.Fprintf(w, `{"status": 200, "response": "Openresty is already installed"}`)
-		//installStatus(w, r)
- 	}
-
- 	//out, err := exec.Command("bash", "-c", "./openresty/install_openresty.sh").Output()
-
- 	//if err != nil {
- 	//   fmt.Printf("%s", err)
- 	//}
-
- 	//fmt.Printf("%s", out)
- 	////return
-
-}
-
-
-
-
-// // func OpenrestyUninstall(w http.ResponseWriter, r *http.Request) {
-// // 	fmt.Fprintf(w, "Do Openresty uninstallation.")
-// // }
-
-// // func OpenrestyUpdate(w http.ResponseWriter, r *http.Request) {
-// // 	fmt.Fprintf(w, "Do Openresty update.")
-// // }
-
-// // func OpenrestyStart(w http.ResponseWriter, r *http.Request) {
-// // 	fmt.Fprintf(w, "Do Openresty restart.")
-// // }

--- a/openresty/openrestyInstall.go
+++ b/openresty/openrestyInstall.go
@@ -1,0 +1,55 @@
+package openresty
+
+import (
+	"fmt"
+	"net/http"
+	//"runtime"
+	"os/exec"
+	//"os"
+	//"bufio"
+	//"strings"
+	"checkos"
+	//"encoding/json"
+)
+
+func openrestyInstall(w http.ResponseWriter, r *http.Request) {
+	os := checkos.DetectOS(w, r)
+
+	if os == "linux" {
+		//fmt.Fprintf(w, `{"%v"}`, os)
+		linuxDist := checkos.DetectLinuxDist(w, r)
+
+		//fmt.Fprintf(w, `{"%v"}`, linuxDist)
+		switch linuxDist {
+		case "Ubuntu":
+			//output, err := exec.Command("openresty", "-v").CombinedOutput()
+			_, err := exec.Command("openresty", "-v").CombinedOutput()
+			if err != nil {
+				//w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintf(w, `{"status": 200, "response": "OpenResty installation started. Call /v1/openresty_ping to find out the status of the installation"}`)
+				//out, err := exec.Command("bash", "-c", "./openresty/install_openresty.sh").Output()
+				_, err := exec.Command("bash", "-c", "./openresty/install_openresty.sh").Output()
+				if err != nil {
+					w.Header().Set("Content-Type", "application/json")
+					fmt.Printf("%s", err)
+					fmt.Fprintf(w, `{"%s"}`, err)
+				}
+
+			} else {
+				//w.Header().Set("Content-Type", "application/json")
+				//w.WriteHeader(http.StatusOK)
+				fmt.Fprintf(w, `{"status": 200, "response": "Openresty is already installed"}`)
+			}
+		case "CentOS":
+			//fmt.Printf("Install Openresty on %v.", distro)
+			fmt.Fprintf(w, `{"%v"}`, linuxDist)
+		case "Amazon Linux":
+			//fmt.Printf("Install Openresty on %v.", distro)
+			fmt.Fprintf(w, `{"%v"}`, linuxDist)
+		default:
+			fmt.Fprintf(w, `{"The operating system is not supported!"}`)
+		}
+		return
+	}
+}

--- a/openresty/openrestyInstall.go.bak
+++ b/openresty/openrestyInstall.go.bak
@@ -1,0 +1,129 @@
+package openresty
+
+import (
+        "fmt"
+        "net/http"
+        "runtime"
+        "os/exec"
+	"os"
+	"bufio"
+	"strings"
+        //"encoding/json"
+)
+
+func openrestyInstall(w http.ResponseWriter, r *http.Request) {
+	             // Detect OS
+        o := runtime.GOOS
+        switch o {
+        case "windows":
+                //fmt.Printf("Windows")
+                w.Header().Set("Content-Type", "application/json")
+                //json.NewEncoder(w).Encode(os)
+                fmt.Fprintf(w, `{"message": "Great, you are running %v."}`, o)
+        case "darwin":
+                // fmt.Println("MAC operating system")
+                w.Header().Set("Content-Type", "application/json")
+                // json.NewEncoder(w).Encode(os)
+                fmt.Fprintf(w, `{"message": "Great, you are running %v."}`, o)
+        case "linux":
+                // fmt.Println("Linux")
+                w.Header().Set("Content-Type", "application/json")
+                //json.NewEncoder(w).Encode(os)
+                //fmt.Fprintf(w, `{"message": "Great, you are running %v."}`, o)
+                // Detect Linux distribution
+                detectLinuxDist(w, r, o)
+                // Install Openresty
+                // InstallOpenresty()
+
+        default:
+                // fmt.Printf("%s.\n", os)
+                //fmt.Printf("The operating system is not supported!")
+                w.Header().Set("Content-Type", "application/json")
+                fmt.Fprintf(w, `{"message": "The operating system is not supported!"}`)
+        }
+
+}
+func detectLinuxDist(w http.ResponseWriter, r *http.Request, o string) {
+        file, err := os.Open("/etc/os-release")
+        if err != nil {
+                panic(err)
+        }
+        defer file.Close()
+
+        scanner := bufio.NewScanner(file)
+        for scanner.Scan() {
+                line := scanner.Text()
+                if strings.HasPrefix(line, "NAME=") {
+                        distro := strings.TrimPrefix(line, "NAME=")
+                        distro = strings.Trim(distro, "\"")
+                        // fmt.Println("Distribution:", distro)
+                        // fmt.Println(distro)
+                        w.Header().Set("Content-Type", "application/json")
+                        //fmt.Fprintf(w, `{"message": "You are running %v Linux!"}`, distro)
+                        detectLinuxFlavour(w, r, distro)
+                        break
+                }
+        }
+}
+
+func detectLinuxFlavour (w http.ResponseWriter, r *http.Request, distro string) {
+        switch distro {
+        case "Ubuntu":
+                //fmt.Fprintf(w, `{"Install Openresty on %v Linux......\n"}`, distro)
+                ubuntuopenrestyInstall(w, r)
+                //installStatus()
+                //http.HandleFunc("/v1/openresty_install_status", installStatus())
+                //out, err := exec.Command("bash", "-c", "./install_openresty.sh").Output()
+                //if err != nil {
+                //   fmt.Printf("%s", err)
+                //}
+                //fmt.Printf("%s", out)
+        case "CentOS":
+                fmt.Printf("Install Openresty on %v.", distro)
+        case "Amazon Linux":
+                fmt.Printf("Install Openresty on %v.", distro)
+        default:
+                fmt.Println("The operating system is not supported!.")
+        }
+ }
+
+func ubuntuopenrestyInstall (w http.ResponseWriter, r *http.Request) {
+
+        //output, err := exec.Command("openresty", "-v").CombinedOutput()
+        _, err := exec.Command("openresty", "-v").CombinedOutput()
+        if err != nil {
+                //w.Header().Set("Content-Type", "application/json")
+                w.WriteHeader(http.StatusOK)
+                fmt.Fprintf(w, `{"status": 200, "response": "OpenResty installation started. Call /v1/openresty_ping to find out the status of the installation"}`)
+                //fmt.Println("OpenResty is not installed")
+                //return
+                //out, err := exec.Command("bash", "-c", "./openresty/install_openresty.sh").Output()
+                _, err := exec.Command("bash", "-c", "./openresty/install_openresty.sh").Output()
+                if err != nil {
+                        w.Header().Set("Content-Type", "application/json")
+                        fmt.Printf("%s", err)
+                        fmt.Fprintf(w, `{"%s"}`, err)
+
+                }
+
+                //installStatus(w, r)
+
+                //fmt.Printf("%s", out)
+        } else {
+                //w.Header().Set("Content-Type", "application/json")
+                //w.WriteHeader(http.StatusOK)
+                //fmt.Printf("Openresty is already installed.\n")
+                fmt.Fprintf(w, `{"status": 200, "response": "Openresty is already installed"}`)
+                //installStatus(w, r)
+        }
+
+        //out, err := exec.Command("bash", "-c", "./openresty/install_openresty.sh").Output()
+
+        //if err != nil {
+        //   fmt.Printf("%s", err)
+        //}
+
+        //fmt.Printf("%s", out)
+        ////return
+
+}

--- a/openresty/openrestyUninstall.go
+++ b/openresty/openrestyUninstall.go
@@ -1,0 +1,60 @@
+package openresty
+
+import (
+	"fmt"
+	"net/http"
+	//"runtime"
+	"os/exec"
+	//"os"
+	//"bufio"
+	//"strings"
+	"checkos"
+	//"encoding/json"
+)
+
+func openrestyUninstall(w http.ResponseWriter, r *http.Request) {
+	os := checkos.DetectOS(w, r)
+
+	if os == "linux" {
+		//fmt.Fprintf(w, `{"%v"}`, os)
+		linuxDist := checkos.DetectLinuxDist(w, r)
+
+		//fmt.Fprintf(w, `{"%v"}`, linuxDist)
+		switch linuxDist {
+		case "Ubuntu":
+			//output, err := exec.Command("openresty", "-v").CombinedOutput()
+			_, err := exec.Command("openresty", "-v").CombinedOutput()
+			if err != nil {
+				//w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				//fmt.Fprintf(w, `{"status": 200, "response": "OpenResty uninstallation started\n"}`)
+				fmt.Fprintf(w, `{"Openrety is not installed!: %v\n"}`, err)
+				return
+				//fmt.Println("OpenResty is not installed")
+				//return
+			} else {
+				//w.Header().Set("Content-Type", "application/json")
+				//w.WriteHeader(http.StatusOK)
+				//fmt.Printf("Openresty is already installed.\n")
+				//out, err := exec.Command("bash", "-c", "./openresty/install_openresty.sh").Output()
+				_, err := exec.Command("bash", "-c", "./openresty/uninstall_openresty.sh").Output()
+				if err != nil {
+					w.Header().Set("Content-Type", "application/json")
+					fmt.Fprintf(w, `{"Openresty is not installed. %s"}`, err)
+
+				}
+				fmt.Fprintf(w, `{"status": 200, "response": "Successfully uninstalled Openresty"}`)
+				//installStatus(w, r)
+			}
+		case "CentOS":
+			//fmt.Printf("Install Openresty on %v.", distro)
+			fmt.Fprintf(w, `{"%v"}`, linuxDist)
+		case "Amazon Linux":
+			//fmt.Printf("Install Openresty on %v.", distro)
+			fmt.Fprintf(w, `{"%v"}`, linuxDist)
+		default:
+			fmt.Fprintf(w, `{"The operating system is not supported!"}`)
+		}
+		return
+	}
+}

--- a/openresty/openrestyUninstall.go.bak
+++ b/openresty/openrestyUninstall.go.bak
@@ -1,0 +1,129 @@
+package openresty
+
+import (
+        "fmt"
+        "net/http"
+        "runtime"
+        "os/exec"
+	"os"
+	"bufio"
+	"strings"
+        //"encoding/json"
+)
+
+func openrestyUninstall(w http.ResponseWriter, r *http.Request) {
+             // Detect OS
+        o := runtime.GOOS
+        switch o {
+        case "windows":
+                //fmt.Printf("Windows")
+                w.Header().Set("Content-Type", "application/json")
+                //json.NewEncoder(w).Encode(os)
+                fmt.Fprintf(w, `{"message": "Great, you are running %v."}`, o)
+        case "darwin":
+                // fmt.Println("MAC operating system")
+                w.Header().Set("Content-Type", "application/json")
+                // json.NewEncoder(w).Encode(os)
+                fmt.Fprintf(w, `{"message": "Great, you are running %v."}`, o)
+        case "linux":
+                // fmt.Println("Linux")
+                w.Header().Set("Content-Type", "application/json")
+                //json.NewEncoder(w).Encode(os)
+                //fmt.Fprintf(w, `{"message": "Great, you are running %v."}`, o)
+                // Detect Linux distribution
+                detectLinuxDist(w, r, o)
+                // Install Openresty
+                // InstallOpenresty()
+
+        default:
+                // fmt.Printf("%s.\n", os)
+                //fmt.Printf("The operating system is not supported!")
+                w.Header().Set("Content-Type", "application/json")
+                fmt.Fprintf(w, `{"message": "The operating system is not supported!"}`)
+        }
+
+}
+
+func detectLinuxDist(w http.ResponseWriter, r *http.Request, o string) {
+        file, err := os.Open("/etc/os-release")
+        if err != nil {
+                panic(err)
+        }
+        defer file.Close()
+
+        scanner := bufio.NewScanner(file)
+        for scanner.Scan() {
+                line := scanner.Text()
+                if strings.HasPrefix(line, "NAME=") {
+                        distro := strings.TrimPrefix(line, "NAME=")
+                        distro = strings.Trim(distro, "\"")
+                        // fmt.Println("Distribution:", distro)
+                        // fmt.Println(distro)
+                        w.Header().Set("Content-Type", "application/json")
+                        //fmt.Fprintf(w, `{"message": "You are running %v Linux!"}`, distro)
+                        detectLinuxFlavour(w, r, distro)
+                        break
+                }
+        }
+}
+
+func detectLinuxFlavour (w http.ResponseWriter, r *http.Request, distro string) {
+        switch distro {
+        case "Ubuntu":
+                //fmt.Fprintf(w, `{"Install Openresty on %v Linux......\n"}`, distro)
+                ubuntuopenrestyUninstall(w, r)
+                //installStatus()
+                //http.HandleFunc("/v1/openresty_install_status", installStatus())
+                //out, err := exec.Command("bash", "-c", "./install_openresty.sh").Output()
+                //if err != nil {
+                //   fmt.Printf("%s", err)
+                //}
+                //fmt.Printf("%s", out)
+        case "CentOS":
+                fmt.Printf("Install Openresty on %v.", distro)
+        case "Amazon Linux":
+                fmt.Printf("Install Openresty on %v.", distro)
+        default:
+                fmt.Println("The operating system is not supported!.")
+        }
+ }
+
+
+func ubuntuopenrestyUninstall (w http.ResponseWriter, r *http.Request) {
+
+        //output, err := exec.Command("openresty", "-v").CombinedOutput()
+        _, err := exec.Command("openresty", "-v").CombinedOutput()
+        if err != nil {
+                //w.Header().Set("Content-Type", "application/json")
+                w.WriteHeader(http.StatusOK)
+                //fmt.Fprintf(w, `{"status": 200, "response": "OpenResty uninstallation started\n"}`)
+		fmt.Fprintf(w, `{"Error: %v\n"}`, err)
+		return
+                //fmt.Println("OpenResty is not installed")
+                //return
+        } else {
+                //w.Header().Set("Content-Type", "application/json")
+                //w.WriteHeader(http.StatusOK)
+                //fmt.Printf("Openresty is already installed.\n")
+                //out, err := exec.Command("bash", "-c", "./openresty/install_openresty.sh").Output()
+		_, err := exec.Command("bash", "-c", "./openresty/uninstall_openresty.sh").Output()
+                if err != nil {
+                        w.Header().Set("Content-Type", "application/json")
+                        fmt.Printf("%s", err)
+                        fmt.Fprintf(w, `{"%s"}`, err)
+
+                }
+                fmt.Fprintf(w, `{"status": 200, "response": "Successfully uninstalled Openresty"}`)
+                //installStatus(w, r)
+        }
+
+        //out, err := exec.Command("bash", "-c", "./openresty/install_openresty.sh").Output()
+
+        //if err != nil {
+        //   fmt.Printf("%s", err)
+        //}
+
+        //fmt.Printf("%s", out)
+        ////return
+
+}

--- a/openresty/uninstall_openresty.sh
+++ b/openresty/uninstall_openresty.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo apt remove openresty -y


### PR DESCRIPTION
Create the checkos package/module to separately handle the logic for checking the operating system outside the openrestyInstall.go and openrestyUninstall.go functions.

I have kept the old functions (ending with .bak file extension) for installing and uninstalling Openresty so that you can see how the code has been modified. These old functions will be removed later as they are not being used.